### PR TITLE
 Process Noise Upgrade 2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "2.0.1"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
+DiffEqNoiseProcess = "77a26b50-5914-5dd7-bc55-306e6241c503"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Integrals = "de52edbc-65ea-441a-8357-d3a637375a31"
 KernelDensity = "5ab0869b-81aa-558d-bb23-cbf5423bbe9b"

--- a/Project.toml
+++ b/Project.toml
@@ -47,9 +47,10 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 SymPy = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestExtras = "5ed8adda-3752-4e41-b88a-e8b09835ee3a"
 
 [targets]
-test = ["Test", "SafeTestsets", "TestExtras", "Pkg", "PkgBenchmark", "BenchmarkTools", "ReferenceTests", "SymPy", "Random", "OrdinaryDiffEq", "ComponentArrays", "ForwardDiff", "Integrals", "IntegralsCubature", "IntegralsCuba", "FiniteDiff", "RecursiveArrayTools"]
+test = ["Test", "SafeTestsets", "TestExtras", "Pkg", "PkgBenchmark", "BenchmarkTools", "ReferenceTests", "SymPy", "Random", "OrdinaryDiffEq", "ComponentArrays", "ForwardDiff", "Integrals", "IntegralsCubature", "IntegralsCuba", "FiniteDiff", "RecursiveArrayTools", "StochasticDiffEq"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 DiffEqGPU = "071ae1c0-96b5-11e9-1965-c90190d839ea"
+DiffEqNoiseProcess = "77a26b50-5914-5dd7-bc55-306e6241c503"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
@@ -12,6 +13,7 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 SciMLExpectations = "afe9f18d-7609-4d0e-b7b7-af0cb72b8ea8"
 SciMLSensitivity = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
 StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
+StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 
 [compat]

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -6,6 +6,7 @@ pages = [
         "tutorials/introduction.md",
         "tutorials/optimization_under_uncertainty.md",
         "tutorials/gpu_bayesian.md",
+        "tutorials/process_noise.md"
     ],
     "Manual" => [
         "manual/problem.md",

--- a/docs/src/tutorials/process_noise.md
+++ b/docs/src/tutorials/process_noise.md
@@ -1,0 +1,30 @@
+# Expectation of process noise
+
+SciMLExpectations.jl is able to calculate the average trajectory of a stochastic differential equation.
+This done by representing the Wiener process using the [Kosambi–Karhunen–Loève theorem](https://en.wikipedia.org/wiki/Kosambi%E2%80%93Karhunen%E2%80%93Lo%C3%A8ve_theorem#The_Wiener_process).
+
+
+```@example process_noise
+using IntegralsCuba
+using SciMLExpectations
+using StochasticDiffEq
+using DiffEqNoiseProcess
+using Distributions
+
+f(du, u, p, t) = (du .= u)
+g(du, u, p, t) = (du .= u)
+u0 = collect(1:4)
+
+W = WienerProcess(0.0, 0.0, 0.0)
+prob = SDEProblem(f, g, u0, (0.0, 1.0), noise=W)
+sm = ProcessNoiseSystemMap(prob, 5, LambaEM())
+cov(x, u, p) = x, p
+observed(sol, p) = sol[:, end]
+exprob = ExpectationProblem(sm, observed, cov; nout=length(u0))
+sol1 = solve(exprob, Koopman(), ireltol=1e-1, iabstol=1e-1,batch=2, quadalg = CubaSUAVE())
+sol1.u
+```
+```@example process_noise
+sol2 = solve(exprob, MonteCarlo(10_000))
+sol2.u
+```

--- a/src/SciMLExpectations.jl
+++ b/src/SciMLExpectations.jl
@@ -4,15 +4,16 @@ module SciMLExpectations
 using DiffEqBase, SciMLBase, Statistics, Reexport, RecursiveArrayTools, StaticArrays,
       Distributions, KernelDensity, Zygote, LinearAlgebra, Random
 using Parameters: @unpack
+import DiffEqNoiseProcess
 
 @reexport using Integrals
 import DiffEqBase: solve
 
-include("system_utils.jl")
 include("distribution_utils.jl")
 include("problem_types.jl")
 include("solution_types.jl")
 include("expectation.jl")
+include("system_utils.jl")
 
 # Type Piracy, should upstream
 Base.eltype(K::UnivariateKDE) = eltype(K.density)
@@ -21,6 +22,7 @@ Base.maximum(K::UnivariateKDE) = maximum(K.x)
 Base.extrema(K::UnivariateKDE) = minimum(K), maximum(K)
 
 export Koopman, MonteCarlo, PrefusedAD, PostfusedAD, NonfusedAD
-export GenericDistribution, SystemMap, ExpectationProblem, build_integrand
+export GenericDistribution, SystemMap, ProcessNoiseSystemMap, ExpectationProblem,
+       build_integrand
 
 end

--- a/src/SciMLExpectations.jl
+++ b/src/SciMLExpectations.jl
@@ -9,11 +9,13 @@ import DiffEqNoiseProcess
 @reexport using Integrals
 import DiffEqBase: solve
 
-include("distribution_utils.jl")
 include("problem_types.jl")
+include("distribution_utils.jl")
 include("solution_types.jl")
-include("expectation.jl")
 include("system_utils.jl")
+include("expectation.jl")
+
+
 
 # Type Piracy, should upstream
 Base.eltype(K::UnivariateKDE) = eltype(K.density)

--- a/src/expectation.jl
+++ b/src/expectation.jl
@@ -132,7 +132,7 @@ function DiffEqBase.solve(prob::ExpectationProblem, expalg::Koopman, args...;
                           quadalg = HCubatureJL(),
                           ireltol = 1e-2, iabstol = 1e-2,
                           kwargs...) where {A <: AbstractExpectationADAlgorithm}
-    integrand = build_integrand(prob, expalg, Val(batch > 1))
+    integrand = build_integrand(prob, expalg, Val(batch > 0))
     lb, ub = extrema(prob.d)
 
     sol = integrate(quadalg, expalg.sensealg, integrand, lb, ub, prob.params;
@@ -148,7 +148,7 @@ function integrate(quadalg, adalg::AbstractExpectationADAlgorithm, f, lb::TB, ub
                    nout = 1, batch = 0,
                    kwargs...) where {TB}
     #TODO check batch iip type stability w/ IntegralProblem{XXXX}
-    prob = IntegralProblem{batch > 1}(f, lb, ub, p; nout = nout, batch = batch)
+    prob = IntegralProblem{batch > 0}(f, lb, ub, p; nout = nout, batch = batch)
     solve(prob, quadalg; kwargs...)
 end
 

--- a/src/expectation.jl
+++ b/src/expectation.jl
@@ -39,16 +39,6 @@ function build_integrand(prob::ExpectationProblem, ::Koopman, ::Val{false})
     end
 end
 
-# Builds integrand for DEProblems
-function build_integrand(prob::ExpectationProblem{F}, ::Koopman,
-                         ::Val{false}) where {F <: SystemMap}
-    @unpack S, g, h, d = prob
-    function (x, p)
-        ū, p̄ = h(x, p.x[1], p.x[2])
-        g(S(ū, p̄), p̄) * pdf(d, x)
-    end
-end
-
 function _make_view(x::Union{Vector{T}, Adjoint{T, Vector{T}}}, i) where {T}
     @view x[i]
 end

--- a/src/expectation.jl
+++ b/src/expectation.jl
@@ -1,36 +1,3 @@
-abstract type AbstractExpectationADAlgorithm end
-struct NonfusedAD <: AbstractExpectationADAlgorithm end
-struct PrefusedAD <: AbstractExpectationADAlgorithm
-    norm_partials::Bool
-end
-PrefusedAD() = PrefusedAD(true)
-struct PostfusedAD <: AbstractExpectationADAlgorithm
-    norm_partials::Bool
-end
-PostfusedAD() = PostfusedAD(true)
-
-abstract type AbstractExpectationAlgorithm <: DiffEqBase.DEAlgorithm end
-
-"""
-```julia
-Koopman()
-```
-"""
-struct Koopman{TS} <:
-       AbstractExpectationAlgorithm where {TS <: AbstractExpectationADAlgorithm}
-    sensealg::TS
-end
-Koopman() = Koopman(NonfusedAD())
-
-"""
-```julia
-MonteCarlo(trajectories::Int)
-```
-"""
-struct MonteCarlo <: AbstractExpectationAlgorithm
-    trajectories::Int
-end
-
 # Builds integrand for arbitrary functions
 function build_integrand(prob::ExpectationProblem, ::Koopman, ::Val{false})
     @unpack g, d = prob

--- a/src/problem_types.jl
+++ b/src/problem_types.jl
@@ -38,13 +38,6 @@ function ExpectationProblem(g, pdist, params; nout = 1)
     ExpectationProblem(S, g, h, pdist, params, nout)
 end
 
-# Constructor for DEProblems
-function ExpectationProblem(sm::SystemMap, g, h, d; nout = 1)
-    ExpectationProblem(sm, g, h, d,
-                       ArrayPartition(deepcopy(sm.prob.u0), deepcopy(sm.prob.p)),
-                       nout)
-end
-
 distribution(prob::ExpectationProblem) = prob.d
 mapping(prob::ExpectationProblem) = prob.S
 observable(prob::ExpectationProblem) = prob.g

--- a/src/system_utils.jl
+++ b/src/system_utils.jl
@@ -1,5 +1,77 @@
 #Callable wrapper for DE solves. Enables seperation of args/kwargs...
 
+abstract type AbstractSystemMap end
+
+## Abstract System Map Interface
+
+# Builds integrand for DEProblems
+function build_integrand(prob::ExpectationProblem{F}, ::Koopman,
+                         ::Val{false}) where {F <: AbstractSystemMap}
+    @unpack S, g, h, d = prob
+    function (x, p)
+        ū, p̄ = h(x, p.x[1], p.x[2])
+        g(S(ū, p̄), p̄) * pdf(d, x)
+    end
+end
+
+function build_integrand(prob::ExpectationProblem{F}, ::Koopman,
+                         ::Val{true}) where {F <: AbstractSystemMap}
+    @unpack S, g, h, d = prob
+
+    if prob.nout == 1 # TODO fix upstream in quadrature, expected sizes depend on quadrature method is requires different copying based on nout > 1
+        set_result! = @inline function (dx, sol)
+            dx[:] .= sol[:]
+        end
+    else
+        set_result! = @inline function (dx, sol)
+            dx .= reshape(sol[:, :], size(dx))
+        end
+    end
+
+    prob_func = function (prob, i, repeat, x)  # TODO is it better to make prob/output funcs outside of integrand, then call w/ closure?
+        u0, p = h((_make_view(x, i)), prob.u0, prob.p)
+        remake(prob, u0 = u0, p = p)
+    end
+
+    output_func(sol, i, x) = (g(sol, sol.prob.p) * pdf(d, (_make_view(x, i))), false)
+
+    function (dx, x, p) where {T}
+        trajectories = size(x, 2)
+        # TODO How to inject ensemble method in solve? currently in SystemMap, but does that make sense?
+        ensprob = EnsembleProblem(S.prob; output_func = (sol, i) -> output_func(sol, i, x),
+                                  prob_func = (prob, i, repeat) -> prob_func(prob, i,
+                                                                             repeat, x))
+        sol = solve(ensprob, S.args...; trajectories = trajectories, S.kwargs...)
+        set_result!(dx, sol)
+        nothing
+    end
+end
+
+# solve expectation over DEProblem via MonteCarlo
+function DiffEqBase.solve(exprob::ExpectationProblem{F},
+                          expalg::MonteCarlo) where {F <: AbstractSystemMap}
+    d = distribution(exprob)
+    cov = input_cov(exprob)
+    S = mapping(exprob)
+    g = observable(exprob)
+
+    prob_func = function (prob, i, repeat)
+        u0, p = cov(rand(d), prob.u0, prob.p)
+        remake(prob, u0 = u0, p = p)
+    end
+
+    output_func(sol, i) = (g(sol, sol.prob.p), false)
+
+    monte_prob = EnsembleProblem(S.prob;
+                                 output_func = output_func,
+                                 prob_func = prob_func)
+    sol = solve(monte_prob, S.args...; trajectories = expalg.trajectories, S.kwargs...)
+    ExpectationSolution(mean(sol.u), nothing, nothing)
+end
+
+### Concrete System Maps
+
+
 """
 ```julia
 SystemMap(prob, args...; kwargs...)
@@ -32,4 +104,100 @@ function (sm::SystemMap{DT})(u0, p) where {DT}
                       u0 = convert(typeof(sm.prob.u0), u0),
                       p = convert(typeof(sm.prob.p), p))
     solve(prob, sm.alg; sm.kwargs...)
+end
+
+function ExpectationProblem(sm::SystemMap, g, h, d; nout = 1)
+    ExpectationProblem(sm, g, h, d,
+                       ArrayPartition(deepcopy(sm.prob.u0), deepcopy(sm.prob.p)),
+                       nout)
+end
+
+"""
+```julia
+ProcessNoiseSystemMap(prob, args...; kwargs...)
+```
+
+Representation of a system solution map for a given `prob::DEProblem`. `args` and `kwargs`
+are forwarded to the equation solver.
+"""
+struct ProcessNoiseSystemMap{DT <: DiffEqBase.DEProblem, A, K} <: AbstractSystemMap
+    prob::DT
+    n::Int
+    args::A
+    kwargs::K
+end
+ProcessNoiseSystemMap(prob, n, args...; kwargs...) = ProcessNoiseSystemMap(prob, n, args, kwargs)
+
+function (sm::ProcessNoiseSystemMap{DT})(Z, p) where {DT}
+    W(t) = sqrt(2) * sum(Z[k] * sin((k - 0.5) * pi * t) / ((k - 0.5) * pi) for k in 1:length(Z))
+    prob::DT = remake(sm.prob, p = convert(typeof(sm.prob.p), p),
+                               noise = NoiseFunction{false}(prob.tspan[1],W))
+    solve(prob, sm.args...; sm.kwargs...)
+end
+
+function ExpectationProblem(sm::ProcessNoiseSystemMap, g, h; nout = 1)
+    d = GenericDistribution((Normal() for i in 1:sm.n)...)
+    ExpectationProblem(sm, g, h, d, deepcopy(sm.prob.p), nout)
+end
+
+function DiffEqBase.solve(exprob::ExpectationProblem{F},
+                          expalg::MonteCarlo) where {F <: ProcessNoiseSystemMap}
+    d = distribution(exprob)
+    cov = input_cov(exprob)
+    S = mapping(exprob)
+    g = observable(exprob)
+
+    prob_func = function (prob, i, repeat)
+        Z, p = cov(rand(d), prob.u0, prob.p)
+        function W(u,p,t)
+            sqrt(2) *
+            sum(Z[k] * sin((k - 0.5) * pi * t) / ((k - 0.5) * pi) for k in 1:length(Z))
+        end
+        remake(prob, p = p, noise = DiffEqNoiseProcess.NoiseFunction{false}(prob.tspan[1], W))
+    end
+
+    output_func(sol, i) = (g(sol, sol.prob.p), false)
+
+    monte_prob = EnsembleProblem(S.prob;
+                                 output_func = output_func,
+                                 prob_func = prob_func)
+    sol = solve(monte_prob, S.args...; trajectories = expalg.trajectories, S.kwargs...)
+    ExpectationSolution(mean(sol.u), nothing, nothing)
+end
+
+function build_integrand(prob::ExpectationProblem{F}, ::Koopman,
+                         ::Val{true}) where {F <: AbstractSystemMap}
+    @unpack S, g, h, d = prob
+
+    if prob.nout == 1 # TODO fix upstream in quadrature, expected sizes depend on quadrature method is requires different copying based on nout > 1
+        set_result! = @inline function (dx, sol)
+            dx[:] .= sol[:]
+        end
+    else
+        set_result! = @inline function (dx, sol)
+            dx .= reshape(sol[:, :], size(dx))
+        end
+    end
+
+    prob_func = function (prob, i, repeat, x)
+        Z, p = h((_make_view(x, i)), prob.u0, prob.p)
+        function W(u,p,t)
+            sqrt(2) *
+            sum(Z[k] * sin((k - 0.5) * pi * t) / ((k - 0.5) * pi) for k in 1:length(Z))
+        end
+        remake(prob, p = p, noise = DiffEqNoiseProcess.NoiseFunction{false}(prob.tspan[1], W))
+    end
+
+    output_func(sol, i, x) = (g(sol, sol.prob.p) * pdf(d, (_make_view(x, i))), false)
+
+    function (dx, x, p) where {T}
+        trajectories = size(x, 2)
+        # TODO How to inject ensemble method in solve? currently in SystemMap, but does that make sense?
+        ensprob = EnsembleProblem(S.prob; output_func = (sol, i) -> output_func(sol, i, x),
+                                  prob_func = (prob, i, repeat) -> prob_func(prob, i,
+                                                                             repeat, x))
+        sol = solve(ensprob, S.args...; trajectories = trajectories, S.kwargs...)
+        set_result!(dx, sol)
+        nothing
+    end
 end

--- a/test/processnoise.jl
+++ b/test/processnoise.jl
@@ -1,0 +1,21 @@
+using IntegralsCuba
+using SciMLExpectations
+using StochasticDiffEq
+using DiffEqNoiseProcess
+using Distributions
+
+f(du, u, p, t) = (du .= u)
+g(du, u, p, t) = (du .= u)
+u0 = collect(1:4)
+
+W = WienerProcess(0.0, 0.0, 0.0)
+prob = SDEProblem(f, g, u0, (0.0, 1.0), noise=W)
+sm = ProcessNoiseSystemMap(prob, 5, LambaEM())
+cov(x, u, p) = x, p
+observed(sol, p) = sol[:, end]
+exprob = ExpectationProblem(sm, observed, cov; nout=length(u0))
+sol2 = solve(exprob, MonteCarlo(10_000))
+sol2.u
+sol1 = solve(exprob, Koopman(), ireltol=1e-1, iabstol=1e-1,batch=2,quadalg = CubaSUAVE())
+sol1.u
+isapprox(sol1.u, sol2.u,rtol=1e-2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,3 +3,4 @@ using SafeTestsets
 @safetestset "Expectation Interface Tests" begin include("interface.jl") end
 @safetestset "Expectation Solve Tests" begin include("solve.jl") end
 @safetestset "Expectation Differentiation Tests" begin include("differentiation.jl") end
+@safetestset "Expectation Process Noise Tests" begin include("processnoise.jl") end


### PR DESCRIPTION
Continued from #68 and #83 .
```julia
using SciMLExpectations
using IntegralsCuba
using StochasticDiffEq
using DiffEqNoiseProcess
using Distributions

f(du, u, p, t) = (du .= u)
g(du, u, p, t) = (du .= u)
u0 = collect(1:4)

W = WienerProcess(0.0, 0.0, 0.0)
prob = SDEProblem(f, g, u0, (0.0, 1.0), noise=W)
sm = ProcessNoiseSystemMap(prob, 5, LambaEM())
cov(x, u, p) = x, p
observed(sol, p) = sol[:, end]
exprob = ExpectationProblem(sm, observed, cov; nout=length(u0))
sol2 = solve(exprob, MonteCarlo(10_000))
sol2.u
sol1 = solve(exprob, Koopman(), ireltol=1e-1, iabstol=1e-1,batch=2,quadalg = CubaSUAVE())
sol1.u

```

```julia
julia> sol1.u
4-element Vector{Float64}:
  4.048893149801676
  8.097786299603351
 12.146679449405037
 16.195572599206702

julia> sol2.u
4-element Vector{Float64}:
  3.9792758125713807
  7.9585516251427615
 11.937827437714137
 15.917103250285523
```

Issues encountered:

- Corrected the definition for inplace, out of place currently not yet implemented
- decreased the number of basis functions for the process noise, the 100 dimensional integral with CubaSuave was giving NaN results.  The PDFs in the integrand become much too small.
- Used truncated distributions for the process noise, for two reasons:
	- the integrand resulting from the automatic handling of the infinite bounds seem to be more variable inside the transformed domain.  Manually bounding the domain to regions of high probability makes the integrand more flat.
	- there is a bug with some combination of iip, batch and nout where the automatic handling of the infinite bounds fails.
	  This has to be tracked down in Integrals.jl
	- Truncating the distributions is, however, problematic when increasing the number of basis functions,
	  since most of the volume of the integrand is in the truncated part.
	- There exist quadrature rules specialized for multivariate normal expectations.
- Similarly, some of the quadrature methods need better erorr messages for which combinations of iip, batch and nout they work
- Not all SDE solvers are compatible with the way the process noise via DiffEqNoiseFunction is implemented, better error messages needed here.
- The original example was a matrix differential equation. I simplified to a vector differential equation.
  Integrals.jl seems to only work with flat vectors due to the batching interface.
- I think the current implementation of the process noise only works for tspan=(0.0,1.0)