### PR TITLE
Require LatticeRules 0.0.2 (32-bit LatticeRule32)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
+LatticeRules = "0.0.2"
 Aqua = "0.8"
 BenchmarkTools = "1"
 ComponentArrays = "0.15.37"
@@ -51,6 +52,7 @@ ZygoteRules = "0.2"
 julia = "1.10"
 
 [extras]
+LatticeRules = "73f95e8e-ec14-4e6a-8b18-0d2e271c4e55"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
@@ -71,4 +73,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestExtras = "5ed8adda-3752-4e41-b88a-e8b09835ee3a"
 
 [targets]
-test = ["Test", "Aqua", "SafeTestsets", "SciMLTesting", "TestExtras", "PkgBenchmark", "BenchmarkTools", "ReferenceTests", "Random", "OrdinaryDiffEq", "ComponentArrays", "ForwardDiff", "Integrals", "Cubature", "Cuba", "FiniteDiff", "RecursiveArrayTools", "StochasticDiffEq"]
+test = ["LatticeRules", "Test", "Aqua", "SafeTestsets", "SciMLTesting", "TestExtras", "PkgBenchmark", "BenchmarkTools", "ReferenceTests", "Random", "OrdinaryDiffEq", "ComponentArrays", "ForwardDiff", "Integrals", "Cubature", "Cuba", "FiniteDiff", "RecursiveArrayTools", "StochasticDiffEq"]


### PR DESCRIPTION
## Summary
Force LatticeRules ≥0.0.2 so QuasiMonteCarlo LatticeRuleSample precompile works on i686 (0.0.1 rejects `typemax(UInt32)+1`-style bounds).

## Test plan
- [ ] x86 Core green

Made with [Cursor](https://cursor.com)