### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "OrdinaryDiffEq,Distributions,StableRNGs"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,43 @@
+using SciMLExpectations, OrdinaryDiffEq, Distributions, BenchmarkTools
+using StableRNGs
+
+const SUITE = BenchmarkGroup()
+const rng = StableRNG(123)
+
+# Pendulum ODE
+function pend!(du, u, p, t)
+    du[1] = u[2]
+    du[2] = -9.807 * sin(u[1])
+    return nothing
+end
+u0 = [0.0, 1.0]
+tspan = (0.0, 10.0)
+prob = ODEProblem(pend!, u0, tspan)
+
+sm = SystemMap(prob, Tsit5(); saveat = 1.0)
+h(x, u, p) = (u, p)
+g(soln, p) = soln
+gd = product_distribution(Uniform(0.9, 1.1), Uniform(0.9, 1.1))
+ep = ExpectationProblem(sm, g, h, gd)
+
+# =============================================================================
+# Expectation solves
+# =============================================================================
+
+SUITE["expectation"] = BenchmarkGroup()
+
+SUITE["expectation"]["koopman"] = @benchmarkable solve($ep, Koopman())
+SUITE["expectation"]["montecarlo"] = @benchmarkable solve($ep, MonteCarlo(500))
+
+# =============================================================================
+# Construction
+# =============================================================================
+
+SUITE["construct"] = BenchmarkGroup()
+
+SUITE["construct"]["systemmap"] = @benchmarkable SystemMap(
+    $prob, Tsit5(); saveat = 1.0
+)
+SUITE["construct"]["expectation_problem"] = @benchmarkable ExpectationProblem(
+    $sm, $g, $h, $gd
+)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~32s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~32s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md