### PR TITLE
Drop temporary Integrals/MCI URL [sources]

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -76,7 +76,3 @@ TestExtras = "5ed8adda-3752-4e41-b88a-e8b09835ee3a"
 
 [targets]
 test = ["QuasiMonteCarlo", "MonteCarloIntegration", "Test", "Aqua", "SafeTestsets", "SciMLTesting", "TestExtras", "PkgBenchmark", "BenchmarkTools", "ReferenceTests", "Random", "OrdinaryDiffEq", "ComponentArrays", "ForwardDiff", "Integrals", "Cubature", "Cuba", "FiniteDiff", "RecursiveArrayTools", "StochasticDiffEq"]
-
-[sources]
-Integrals = {url = "https://github.com/ChrisRackauckas-Claude/Integrals.jl.git", rev = "bump-mci-0.3"}
-MonteCarloIntegration = {url = "https://github.com/ranjanan/MonteCarloIntegration.jl.git", rev = "master"}


### PR DESCRIPTION
## Summary
- Remove URL `[sources]` for Integrals and MonteCarloIntegration now that MCI 0.3.0 is registered.

## Dependency
Hold merge until **Integrals 5.5.1** is registered (registry Integrals 5.5.0 still Compat-pins MCI to 0.2; QMC 0.4.x needs MCI 0.3).

## Test plan
- [ ] Integrals 5.5.1 in General
- [ ] CI green

Made with [Cursor](https://cursor.com)